### PR TITLE
Update esri links

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ u<!DOCTYPE html>
 												<a class="btn primary centered" href="https://github.com/esriuk"> Browse on GitHub </a>
 											</p>
 											<p class="home-subscription-text"> 
-												Need an <a href="http://developers.esri.com">ArcGIS subscription</a>? &nbsp;Start developing today for <a href="https://developers.arcgis.com/en/plans/">free</a>.
+												Need an <a href="http://location.arcgis.com">ArcGIS subscription</a>? &nbsp;Start developing today for <a href="https://location.arcgis.com/pricing/">free</a>.
 											</p>
 										</div>
 									</div>


### PR DESCRIPTION
two links on the home page are no longer valid, suggesting their replacement to their current counterparts.

@sean-stone 